### PR TITLE
Connect login screen to backend

### DIFF
--- a/PAC/app/src/main/java/com/example/foodly/login/LoginScreen.kt
+++ b/PAC/app/src/main/java/com/example/foodly/login/LoginScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
@@ -38,6 +39,7 @@ fun LoginScreen(
 
     var email by rememberSaveable { mutableStateOf("") }
     var password by rememberSaveable { mutableStateOf("") }
+    val context = LocalContext.current
 
     // Use solid background color for a cleaner M3 look
     Column(
@@ -100,7 +102,7 @@ fun LoginScreen(
 
         // Login Button
         Button(
-            onClick = { viewModel.login(email, password) },
+            onClick = { viewModel.login(email, password, context) },
             enabled = loginUiState != LoginUiState.Loading,
             modifier = Modifier.fillMaxWidth(),
             // M3 buttons have standard shapes, explicit shape might not be needed unless specific design

--- a/PAC/app/src/main/java/com/example/foodly/login/LoginViewModel.kt
+++ b/PAC/app/src/main/java/com/example/foodly/login/LoginViewModel.kt
@@ -1,8 +1,11 @@
 package com.example.foodly.login
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.delay
+import com.example.foodly.api.AuthApiClient
+import com.example.foodly.api.Result
+import com.example.foodly.api.request.LoginRequest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,15 +24,13 @@ class LoginViewModel : ViewModel() {
     private val _uiState = MutableStateFlow<LoginUiState>(LoginUiState.Idle)
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
-    fun login(email: String, password: String) {
+    fun login(email: String, password: String, context: Context) {
         viewModelScope.launch {
             _uiState.value = LoginUiState.Loading
-            // Simulate network delay
-            delay(1500)
-            if (email.equals("test@example.com", ignoreCase = true)) {
-                _uiState.value = LoginUiState.Success
-            } else {
-                _uiState.value = LoginUiState.Error("Invalid email or password.")
+            val result = AuthApiClient.login(LoginRequest(email, password), context)
+            when (result) {
+                is Result.Success -> _uiState.value = LoginUiState.Success
+                is Result.Error -> _uiState.value = LoginUiState.Error(result.message)
             }
         }
     }


### PR DESCRIPTION
## Summary
- hook up login ViewModel with AuthApiClient
- pass Android context from the screen when logging in

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68550fc06e90832d9c1b5143246b7d17